### PR TITLE
Fix nil being passed to Regex.match? in Format validator

### DIFF
--- a/lib/vex/validators/format.ex
+++ b/lib/vex/validators/format.ex
@@ -44,8 +44,8 @@ defmodule Vex.Validators.Format do
   def validate(value, options) when is_list(options) do
     unless_skipping(value, options) do
       pattern = Keyword.get(options, :with)
-      result Regex.match?(pattern, value), message(options, "must have the correct format",
-                                                   value: value)
+      result Regex.match?(pattern, to_string(value)),
+                          message(options, "must have the correct format", value: value)
     end
   end
 

--- a/test/validations/format_test.exs
+++ b/test/validations/format_test.exs
@@ -4,6 +4,7 @@ defmodule FormatTest do
   test "keyword list, provided format validation" do
     assert  Vex.valid?([component: "x1234"], component: [format: [with: ~r/(^x\d+$)/]])
     assert !Vex.valid?([component: "d1234"], component: [format: [with: ~r/(^x\d+$)/]])
+    assert !Vex.valid?([component: nil], component: [format: [with: ~r/(^x\d+$)/]])
   end
 
 end


### PR DESCRIPTION
Previously this would error out with nil being passed to Regex.match?

``` elixir
defmodule User do
  use Vex.Struct

  defstruct email: nil

  validates :email, presence: true, format: ~r/^\S+@\S+\.\S+$/
end
```

This PR converts to a string to fix the issue. I also added a testcase for this scenario. Thanks!
