### PR TITLE
Fix code block indentation to work with iex

### DIFF
--- a/lib/vex/validator/error_message.ex
+++ b/lib/vex/validator/error_message.ex
@@ -19,12 +19,12 @@ defmodule Vex.Validator.ErrorMessage do
 
   ## Examples
 
-    iex> Vex.Validator.ErrorMessage.message(nil, "default")
-    "default"
-    iex> Vex.Validator.ErrorMessage.message([message: "override"], "default")
-    "override"
-    iex> Vex.Validator.ErrorMessage.message([message: "Context #<%= value %>"], "default", value: 2)
-    "Context #2"
+      iex> Vex.Validator.ErrorMessage.message(nil, "default")
+      "default"
+      iex> Vex.Validator.ErrorMessage.message([message: "override"], "default")
+      "override"
+      iex> Vex.Validator.ErrorMessage.message([message: "Context #<%= value %>"], "default", value: 2)
+      "Context #2"
   """
   def message(options, default) do
     if Keyword.keyword?(options) do

--- a/lib/vex/validator/skipping.ex
+++ b/lib/vex/validator/skipping.ex
@@ -18,32 +18,32 @@ defmodule Vex.Validator.Skipping do
 
   ## Examples
 
-    iex> Vex.Validator.Skipping.skip?("", allow_nil: true)
-    false
-    iex> Vex.Validator.Skipping.skip?("", allow_blank: true)
-    true
-    iex> Vex.Validator.Skipping.skip?(nil, allow_nil: true)
-    true
-    iex> Vex.Validator.Skipping.skip?(nil, allow_blank: true)
-    true
-    iex> Vex.Validator.Skipping.skip?(nil, allow_blank: true, allow_nil: true)
-    true
-    iex> Vex.Validator.Skipping.skip?("", allow_blank: true, allow_nil: true)
-    true
-    iex> Vex.Validator.Skipping.skip?(1, allow_nil: true)
-    false
-    iex> Vex.Validator.Skipping.skip?(1, allow_blank: true)
-    false
-    iex> Vex.Validator.Skipping.skip?(1, allow_blank: true, allow_nil: true)
-    false
-    iex> Vex.Validator.Skipping.skip?(1, allow_blank: true, allow_nil: true)
-    false
+      iex> Vex.Validator.Skipping.skip?("", allow_nil: true)
+      false
+      iex> Vex.Validator.Skipping.skip?("", allow_blank: true)
+      true
+      iex> Vex.Validator.Skipping.skip?(nil, allow_nil: true)
+      true
+      iex> Vex.Validator.Skipping.skip?(nil, allow_blank: true)
+      true
+      iex> Vex.Validator.Skipping.skip?(nil, allow_blank: true, allow_nil: true)
+      true
+      iex> Vex.Validator.Skipping.skip?("", allow_blank: true, allow_nil: true)
+      true
+      iex> Vex.Validator.Skipping.skip?(1, allow_nil: true)
+      false
+      iex> Vex.Validator.Skipping.skip?(1, allow_blank: true)
+      false
+      iex> Vex.Validator.Skipping.skip?(1, allow_blank: true, allow_nil: true)
+      false
+      iex> Vex.Validator.Skipping.skip?(1, allow_blank: true, allow_nil: true)
+      false
   """
   def skip?(value, options) do
     cond do
       Keyword.get(options, :allow_blank) -> Vex.Blank.blank?(value)
       Keyword.get(options, :allow_nil)   -> value == nil
       true -> false
-    end      
-  end  
+    end
+  end
 end

--- a/lib/vex/validators/absence.ex
+++ b/lib/vex/validators/absence.ex
@@ -12,34 +12,34 @@ defmodule Vex.Validators.Absence do
 
   ## Examples
 
-    iex> Vex.Validators.Absence.validate(1, true)
-    {:error, "must be absent"}
-    iex> Vex.Validators.Absence.validate(nil, true)
-    :ok
-    iex> Vex.Validators.Absence.validate(false, true)
-    :ok
-    iex> Vex.Validators.Absence.validate("", true)
-    :ok
-    iex> Vex.Validators.Absence.validate([], true)
-    :ok 
-    iex> Vex.Validators.Absence.validate([], true)
-    :ok
-    iex> Vex.Validators.Absence.validate([1], true)
-    {:error, "must be absent"} 
-    iex> Vex.Validators.Absence.validate({1}, true)
-    {:error, "must be absent"}
+      iex> Vex.Validators.Absence.validate(1, true)
+      {:error, "must be absent"}
+      iex> Vex.Validators.Absence.validate(nil, true)
+      :ok
+      iex> Vex.Validators.Absence.validate(false, true)
+      :ok
+      iex> Vex.Validators.Absence.validate("", true)
+      :ok
+      iex> Vex.Validators.Absence.validate([], true)
+      :ok
+      iex> Vex.Validators.Absence.validate([], true)
+      :ok
+      iex> Vex.Validators.Absence.validate([1], true)
+      {:error, "must be absent"}
+      iex> Vex.Validators.Absence.validate({1}, true)
+      {:error, "must be absent"}
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.Absence.__validator__(:message_fields)
-    [value: "The bad value"]
+      iex> Vex.Validators.Absence.__validator__(:message_fields)
+      [value: "The bad value"]
 
   An example:
 
-    iex> Vex.Validators.Absence.validate([1], message: "can't be <%= inspect value %>")
-    {:error, "can't be [1]"}
+      iex> Vex.Validators.Absence.validate([1], message: "can't be <%= inspect value %>")
+      {:error, "can't be [1]"}
   """
   use Vex.Validator
 

--- a/lib/vex/validators/acceptance.ex
+++ b/lib/vex/validators/acceptance.ex
@@ -14,28 +14,28 @@ defmodule Vex.Validators.Acceptance do
 
   ## Examples
 
-    iex> Vex.Validators.Acceptance.validate(1, true)
-    :ok
-    iex> Vex.Validators.Acceptance.validate(nil, true)
-    {:error, "must be accepted"}  
-    iex> Vex.Validators.Acceptance.validate(nil, message: "must be accepted!")
-    {:error, "must be accepted!"}    
-    iex> Vex.Validators.Acceptance.validate(1, [as: "yes"])
-    {:error, ~S(must be accepted with `"yes"`)}
-    iex> Vex.Validators.Acceptance.validate("verily", [as: "verily"])
-    :ok
+      iex> Vex.Validators.Acceptance.validate(1, true)
+      :ok
+      iex> Vex.Validators.Acceptance.validate(nil, true)
+      {:error, "must be accepted"}
+      iex> Vex.Validators.Acceptance.validate(nil, message: "must be accepted!")
+      {:error, "must be accepted!"}
+      iex> Vex.Validators.Acceptance.validate(1, [as: "yes"])
+      {:error, ~S(must be accepted with `"yes"`)}
+      iex> Vex.Validators.Acceptance.validate("verily", [as: "verily"])
+      :ok
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.Acceptance.__validator__(:message_fields)
-    [value: "The bad value"]
+      iex> Vex.Validators.Acceptance.__validator__(:message_fields)
+      [value: "The bad value"]
 
   An example:
 
-    iex> Vex.Validators.Acceptance.validate(nil, message: "<%= inspect value %> doesn't count as accepted")
-    {:error, "nil doesn't count as accepted"}
+      iex> Vex.Validators.Acceptance.validate(nil, message: "<%= inspect value %> doesn't count as accepted")
+      {:error, "nil doesn't count as accepted"}
 
   """
   use Vex.Validator

--- a/lib/vex/validators/by.ex
+++ b/lib/vex/validators/by.ex
@@ -16,34 +16,34 @@ defmodule Vex.Validators.By do
 
   ## Examples
 
-    iex> Vex.Validators.By.validate(2, &(&1 == 2))
-    :ok
-    iex> Vex.Validators.By.validate(3, &(&1 == 2))
-    {:error, "must be valid"}
-    iex> Vex.Validators.By.validate(["foo", "foo"], &is_list/1)
-    :ok
-    iex> Vex.Validators.By.validate("sgge", fn (word) -> word |> String.reverse == "eggs" end)
-    :ok
-    iex> Vex.Validators.By.validate(nil, [function: &is_list/1, allow_nil: true])
-    :ok
-    iex> Vex.Validators.By.validate({}, [function: &is_list/1, allow_blank: true])
-    :ok
-    iex> Vex.Validators.By.validate([1], [function: &is_list/1, message: "must be a list"])
-    :ok
-    iex> Vex.Validators.By.validate("a", [function: &is_list/1, message: "must be a list"])
-    {:error, "must be a list"}
+      iex> Vex.Validators.By.validate(2, &(&1 == 2))
+      :ok
+      iex> Vex.Validators.By.validate(3, &(&1 == 2))
+      {:error, "must be valid"}
+      iex> Vex.Validators.By.validate(["foo", "foo"], &is_list/1)
+      :ok
+      iex> Vex.Validators.By.validate("sgge", fn (word) -> word |> String.reverse == "eggs" end)
+      :ok
+      iex> Vex.Validators.By.validate(nil, [function: &is_list/1, allow_nil: true])
+      :ok
+      iex> Vex.Validators.By.validate({}, [function: &is_list/1, allow_blank: true])
+      :ok
+      iex> Vex.Validators.By.validate([1], [function: &is_list/1, message: "must be a list"])
+      :ok
+      iex> Vex.Validators.By.validate("a", [function: &is_list/1, message: "must be a list"])
+      {:error, "must be a list"}
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.By.__validator__(:message_fields)
-    [value: "The bad value"]
+      iex> Vex.Validators.By.__validator__(:message_fields)
+      [value: "The bad value"]
 
   An example:
 
-    iex> Vex.Validators.By.validate("blah", [function: &is_list/1, message: "<%= inspect value %> isn't a list"])
-    {:error, ~S("blah" isn't a list)}
+      iex> Vex.Validators.By.validate("blah", [function: &is_list/1, message: "<%= inspect value %> isn't a list"])
+      {:error, ~S("blah" isn't a list)}
   """
   use Vex.Validator
 

--- a/lib/vex/validators/confirmation.ex
+++ b/lib/vex/validators/confirmation.ex
@@ -15,32 +15,32 @@ defmodule Vex.Validators.Confirmation do
 
   ## Examples
 
-    iex> Vex.Validators.Confirmation.validate(["foo", "bar"], true)
-    {:error, "must match its confirmation"}
-    iex> Vex.Validators.Confirmation.validate(["foo", "foo"], true)
-    :ok
-    iex> Vex.Validators.Confirmation.validate(["foo", "bar"], message: "<%= confirmation %> isn't the same as <%= value %>!")
-    {:error, "bar isn't the same as foo!"}
-    iex> Vex.Validators.Confirmation.validate([nil, "bar"], true)
-    :ok
-    iex> Vex.Validators.Confirmation.validate(["foo", nil], true)
-    {:error, "must match its confirmation"}
-    iex> Vex.Validators.Confirmation.validate(["foo", nil], message: "must match!")
-    {:error, "must match!"}    
-    iex> Vex.Validators.Confirmation.validate(["", "unneeded"], [allow_blank: true])
-    :ok
+      iex> Vex.Validators.Confirmation.validate(["foo", "bar"], true)
+      {:error, "must match its confirmation"}
+      iex> Vex.Validators.Confirmation.validate(["foo", "foo"], true)
+      :ok
+      iex> Vex.Validators.Confirmation.validate(["foo", "bar"], message: "<%= confirmation %> isn't the same as <%= value %>!")
+      {:error, "bar isn't the same as foo!"}
+      iex> Vex.Validators.Confirmation.validate([nil, "bar"], true)
+      :ok
+      iex> Vex.Validators.Confirmation.validate(["foo", nil], true)
+      {:error, "must match its confirmation"}
+      iex> Vex.Validators.Confirmation.validate(["foo", nil], message: "must match!")
+      {:error, "must match!"}
+      iex> Vex.Validators.Confirmation.validate(["", "unneeded"], [allow_blank: true])
+      :ok
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.Confirmation.__validator__(:message_fields)
-    [value: "The value to confirm", confirmation: "Bad confirmation value"]   
+      iex> Vex.Validators.Confirmation.__validator__(:message_fields)
+      [value: "The value to confirm", confirmation: "Bad confirmation value"]
 
   An example:
 
-    iex> Vex.Validators.Confirmation.validate(["foo", nil], message: "<%= inspect confirmation %> doesn't match <%= inspect value %>")
-    {:error, ~S(nil doesn't match "foo")}
+      iex> Vex.Validators.Confirmation.validate(["foo", nil], message: "<%= inspect confirmation %> doesn't match <%= inspect value %>")
+      {:error, ~S(nil doesn't match "foo")}
 
   """
   use Vex.Validator

--- a/lib/vex/validators/exclusion.ex
+++ b/lib/vex/validators/exclusion.ex
@@ -12,32 +12,31 @@ defmodule Vex.Validators.Exclusion do
 
   ## Examples
 
-    iex> Vex.Validators.Exclusion.validate(1, [1, 2, 3])
-    {:error, "must not be one of [1, 2, 3]"}
-    iex> Vex.Validators.Exclusion.validate(1, [in: [1, 2, 3]])
-    {:error, "must not be one of [1, 2, 3]"}
-    iex> Vex.Validators.Exclusion.validate(1, [in: [1, 2, 3], message: "<%= value %> shouldn't be in <%= inspect list %>"])
-    {:error, "1 shouldn't be in [1, 2, 3]"}
-    iex> Vex.Validators.Exclusion.validate(4, [1, 2, 3])
-    :ok
-    iex> Vex.Validators.Exclusion.validate("a", ~w(a b c))
-    {:error, ~S(must not be one of ["a", "b", "c"])}
-    iex> Vex.Validators.Exclusion.validate("a", in: ~w(a b c), message: "must not be abc, talkin' 'bout 123")
-    {:error, "must not be abc, talkin' 'bout 123"}
+      iex> Vex.Validators.Exclusion.validate(1, [1, 2, 3])
+      {:error, "must not be one of [1, 2, 3]"}
+      iex> Vex.Validators.Exclusion.validate(1, [in: [1, 2, 3]])
+      {:error, "must not be one of [1, 2, 3]"}
+      iex> Vex.Validators.Exclusion.validate(1, [in: [1, 2, 3], message: "<%= value %> shouldn't be in <%= inspect list %>"])
+      {:error, "1 shouldn't be in [1, 2, 3]"}
+      iex> Vex.Validators.Exclusion.validate(4, [1, 2, 3])
+      :ok
+      iex> Vex.Validators.Exclusion.validate("a", ~w(a b c))
+      {:error, ~S(must not be one of ["a", "b", "c"])}
+      iex> Vex.Validators.Exclusion.validate("a", in: ~w(a b c), message: "must not be abc, talkin' 'bout 123")
+      {:error, "must not be abc, talkin' 'bout 123"}
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.Exclusion.__validator__(:message_fields)
-    [value: "The bad value", list: "List"]
+      iex> Vex.Validators.Exclusion.__validator__(:message_fields)
+      [value: "The bad value", list: "List"]
 
   An example:
 
-    iex> Vex.Validators.Exclusion.validate("a", in: ~w(a b c), message: "<%= inspect value %> is a disallowed value")
-    {:error, ~S("a" is a disallowed value)}
+      iex> Vex.Validators.Exclusion.validate("a", in: ~w(a b c), message: "<%= inspect value %> is a disallowed value")
+      {:error, ~S("a" is a disallowed value)}
   """
-
   use Vex.Validator
 
   @message_fields [value: "The bad value", list: "List"]

--- a/lib/vex/validators/format.ex
+++ b/lib/vex/validators/format.ex
@@ -13,30 +13,30 @@ defmodule Vex.Validators.Format do
 
   ## Examples
 
-    iex> Vex.Validators.Format.validate("foo", ~r/^f/)
-    :ok
-    iex> Vex.Validators.Format.validate("foo", ~r/o{3,}/)
-    {:error, "must have the correct format"}
-    iex> Vex.Validators.Format.validate("foo", [with: ~r/^f/])
-    :ok
-    iex> Vex.Validators.Format.validate("bar", [with: ~r/^f/, message: "must start with an f"])
-    {:error, "must start with an f"}
-    iex> Vex.Validators.Format.validate("", [with: ~r/^f/, allow_blank: true])
-    :ok
-    iex> Vex.Validators.Format.validate(nil, [with: ~r/^f/, allow_nil: true])
-    :ok
+      iex> Vex.Validators.Format.validate("foo", ~r/^f/)
+      :ok
+      iex> Vex.Validators.Format.validate("foo", ~r/o{3,}/)
+      {:error, "must have the correct format"}
+      iex> Vex.Validators.Format.validate("foo", [with: ~r/^f/])
+      :ok
+      iex> Vex.Validators.Format.validate("bar", [with: ~r/^f/, message: "must start with an f"])
+      {:error, "must start with an f"}
+      iex> Vex.Validators.Format.validate("", [with: ~r/^f/, allow_blank: true])
+      :ok
+      iex> Vex.Validators.Format.validate(nil, [with: ~r/^f/, allow_nil: true])
+      :ok
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.Format.__validator__(:message_fields)
-    [value: "The bad value"]
+      iex> Vex.Validators.Format.__validator__(:message_fields)
+      [value: "The bad value"]
 
   An example:
 
-    iex> Vex.Validators.Format.validate("bar", [with: ~r/"^f"/, message: "<%= value %> doesn't start with an f"])
-    {:error, "bar doesn't start with an f"}
+      iex> Vex.Validators.Format.validate("bar", [with: ~r/"^f"/, message: "<%= value %> doesn't start with an f"])
+      {:error, "bar doesn't start with an f"}
   """
   use Vex.Validator
 

--- a/lib/vex/validators/inclusion.ex
+++ b/lib/vex/validators/inclusion.ex
@@ -12,32 +12,32 @@ defmodule Vex.Validators.Inclusion do
 
   ## Examples
 
-    iex> Vex.Validators.Inclusion.validate(1, [1, 2, 3])
-    :ok
-    iex> Vex.Validators.Inclusion.validate(1, [in: [1, 2, 3]])
-    :ok
-    iex> Vex.Validators.Inclusion.validate(4, [1, 2, 3])
-    {:error, "must be one of [1, 2, 3]"}
-    iex> Vex.Validators.Inclusion.validate("a", ~w(a b c))
-    :ok
-    iex> Vex.Validators.Inclusion.validate(nil, ~w(a b c))
-    {:error, ~S(must be one of ["a", "b", "c"])}
-    iex> Vex.Validators.Inclusion.validate(nil, [in: ~w(a b c), allow_nil: true])
-    :ok
-    iex> Vex.Validators.Inclusion.validate("", [in: ~w(a b c), allow_blank: true])
-    :ok
+      iex> Vex.Validators.Inclusion.validate(1, [1, 2, 3])
+      :ok
+      iex> Vex.Validators.Inclusion.validate(1, [in: [1, 2, 3]])
+      :ok
+      iex> Vex.Validators.Inclusion.validate(4, [1, 2, 3])
+      {:error, "must be one of [1, 2, 3]"}
+      iex> Vex.Validators.Inclusion.validate("a", ~w(a b c))
+      :ok
+      iex> Vex.Validators.Inclusion.validate(nil, ~w(a b c))
+      {:error, ~S(must be one of ["a", "b", "c"])}
+      iex> Vex.Validators.Inclusion.validate(nil, [in: ~w(a b c), allow_nil: true])
+      :ok
+      iex> Vex.Validators.Inclusion.validate("", [in: ~w(a b c), allow_blank: true])
+      :ok
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.Inclusion.__validator__(:message_fields)
-    [value: "The bad value", list: "List"]
+      iex> Vex.Validators.Inclusion.__validator__(:message_fields)
+      [value: "The bad value", list: "List"]
 
   An example:
 
-    iex> Vex.Validators.Inclusion.validate("a", in: [1, 2, 3], message: "<%= inspect value %> is not an allowed value")
-    {:error, ~S("a" is not an allowed value)}
+      iex> Vex.Validators.Inclusion.validate("a", in: [1, 2, 3], message: "<%= inspect value %> is not an allowed value")
+      {:error, ~S("a" is not an allowed value)}
 
   """
   use Vex.Validator

--- a/lib/vex/validators/length.ex
+++ b/lib/vex/validators/length.ex
@@ -25,45 +25,45 @@ defmodule Vex.Validators.Length do
 
   ## Examples
 
-    iex> Vex.Validators.Length.validate("foo", 3)
-    :ok
-    iex> Vex.Validators.Length.validate("foo", 2)
-    {:error, "must have a length of 2"}
-    iex> Vex.Validators.Length.validate(nil, [is: 2, allow_nil: true])
-    :ok
-    iex> Vex.Validators.Length.validate("", [is: 2, allow_blank: true])
-    :ok
-    iex> Vex.Validators.Length.validate("foo", min: 2, max: 8)
-    :ok
-    iex> Vex.Validators.Length.validate("foo", min: 4)
-    {:error, "must have a length of at least 4"}
-    iex> Vex.Validators.Length.validate("foo", max: 2)
-    {:error, "must have a length of no more than 2"}
-    iex> Vex.Validators.Length.validate("foo", max: 2, message: "must be the right length")
-    {:error, "must be the right length"}
-    iex> Vex.Validators.Length.validate("foo", is: 3)
-    :ok
-    iex> Vex.Validators.Length.validate("foo", is: 2)
-    {:error, "must have a length of 2"}
-    iex> Vex.Validators.Length.validate("foo", in: 1..6)
-    :ok
-    iex> Vex.Validators.Length.validate("foo", in: 8..10)
-    {:error, "must have a length between 8 and 10"}
-    iex> Vex.Validators.Length.validate("four words are here", max: 4, tokenizer: &String.split/1)
-    :ok
+      iex> Vex.Validators.Length.validate("foo", 3)
+      :ok
+      iex> Vex.Validators.Length.validate("foo", 2)
+      {:error, "must have a length of 2"}
+      iex> Vex.Validators.Length.validate(nil, [is: 2, allow_nil: true])
+      :ok
+      iex> Vex.Validators.Length.validate("", [is: 2, allow_blank: true])
+      :ok
+      iex> Vex.Validators.Length.validate("foo", min: 2, max: 8)
+      :ok
+      iex> Vex.Validators.Length.validate("foo", min: 4)
+      {:error, "must have a length of at least 4"}
+      iex> Vex.Validators.Length.validate("foo", max: 2)
+      {:error, "must have a length of no more than 2"}
+      iex> Vex.Validators.Length.validate("foo", max: 2, message: "must be the right length")
+      {:error, "must be the right length"}
+      iex> Vex.Validators.Length.validate("foo", is: 3)
+      :ok
+      iex> Vex.Validators.Length.validate("foo", is: 2)
+      {:error, "must have a length of 2"}
+      iex> Vex.Validators.Length.validate("foo", in: 1..6)
+      :ok
+      iex> Vex.Validators.Length.validate("foo", in: 8..10)
+      {:error, "must have a length between 8 and 10"}
+      iex> Vex.Validators.Length.validate("four words are here", max: 4, tokenizer: &String.split/1)
+      :ok
 
   ## Custom Error Messages
 
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
-    iex> Vex.Validators.Length.__validator__(:message_fields)
-    [value: "Bad value", tokens: "Tokens from value", size: "Number of tokens", min: "Minimum acceptable value", max: "Maximum acceptable value"]
+      iex> Vex.Validators.Length.__validator__(:message_fields)
+      [value: "Bad value", tokens: "Tokens from value", size: "Number of tokens", min: "Minimum acceptable value", max: "Maximum acceptable value"]
 
   An example:
 
-    iex> Vex.Validators.Length.validate("hello my darling", min: 4, tokenizer: &String.split/1,
-    iex>                                                    message: "<%= length tokens %> words isn't enough")
-    {:error, "3 words isn't enough"}
+      iex> Vex.Validators.Length.validate("hello my darling", min: 4, tokenizer: &String.split/1,
+      ...>                                                    message: "<%= length tokens %> words isn't enough")
+      {:error, "3 words isn't enough"}
 
   """
   use Vex.Validator

--- a/lib/vex/validators/presence.ex
+++ b/lib/vex/validators/presence.ex
@@ -1,4 +1,4 @@
-defmodule Vex.Validators.Presence do 
+defmodule Vex.Validators.Presence do
  @moduledoc """
   Ensure a value is present.
 
@@ -8,39 +8,39 @@ defmodule Vex.Validators.Presence do
   ## Options
 
    * `:message`: Optional. A custom error message. May be in EEx format
-      and use the fields described in "Custom Error Messages," below. 
+      and use the fields described in "Custom Error Messages," below.
 
   ## Examples
 
-    iex> Vex.Validators.Presence.validate(1, true)
-    :ok
-    iex> Vex.Validators.Presence.validate(nil, true)
-    {:error, "must be present"}
-    iex> Vex.Validators.Presence.validate(false, true)
-    {:error, "must be present"}
-    iex> Vex.Validators.Presence.validate("", true)
-    {:error, "must be present"}
-    iex> Vex.Validators.Presence.validate([], true)
-    {:error, "must be present"}
-    iex> Vex.Validators.Presence.validate([], true)
-    {:error, "must be present"}   
-    iex> Vex.Validators.Presence.validate([1], true)
-    :ok 
-    iex> Vex.Validators.Presence.validate({1}, true)
-    :ok
+      iex> Vex.Validators.Presence.validate(1, true)
+      :ok
+      iex> Vex.Validators.Presence.validate(nil, true)
+      {:error, "must be present"}
+      iex> Vex.Validators.Presence.validate(false, true)
+      {:error, "must be present"}
+      iex> Vex.Validators.Presence.validate("", true)
+      {:error, "must be present"}
+      iex> Vex.Validators.Presence.validate([], true)
+      {:error, "must be present"}
+      iex> Vex.Validators.Presence.validate([], true)
+      {:error, "must be present"}
+      iex> Vex.Validators.Presence.validate([1], true)
+      :ok
+      iex> Vex.Validators.Presence.validate({1}, true)
+      :ok
 
   ## Custom Error Messages
 
-  Custom error messages (in EEx format), provided as :message, can use the following values:
+  Custom error messages (in EEx format), provided as :message, can use
+  the following values:
 
-    iex> Vex.Validators.Presence.__validator__(:message_fields)
-    [value: "The bad value"]
+      iex> Vex.Validators.Presence.__validator__(:message_fields)
+      [value: "The bad value"]
 
   An example:
 
-    iex> Vex.Validators.Presence.validate([], message: "needs to be more sizable than <%= inspect value %>")
-    {:error, "needs to be more sizable than []"}
-
+      iex> Vex.Validators.Presence.validate([], message: "needs to be more sizable than <%= inspect value %>")
+      {:error, "needs to be more sizable than []"}
   """
   use Vex.Validator
 


### PR DESCRIPTION
`doctest` was working fine, but 4 rather than 2 space indentation is necessary for a markdown codeblock.