### PR TITLE
Add `result/2`, add `validate/1,2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,18 @@ If you only want the errors, use `Vex.errors/1`:
 iex> Vex.errors(another_user)
 [{:error, :password, :length, "must have a length of at least 4"},
  {:error, :password, :confirmation, "must match its confirmation"}]
- ```
+```
+
+The results can be gathered with `Vex.validate/1`:
+
+```elixir
+iex> Vex.results(user)
+:ok
+
+iex> Vex.errors(another_user)
+{:error, [{:password, :length, "must have a length of at least 4"},
+          {:password, :confirmation, "must match its confirmation"}]
+```
 
 Custom Error Messages
 ---------------------

--- a/lib/vex.ex
+++ b/lib/vex.ex
@@ -1,5 +1,35 @@
 defmodule Vex do
 
+  @typep attribute    :: atom
+  @typep name         :: atom
+  @typep error_result :: {:error, attribute, name, term}
+  @typep ok_result    :: {:ok, attribute, name}
+
+
+  @doc """
+  Return `:ok` or an error tuple with the list of errors.
+
+  ## Examples
+
+      iex> Vex.validate([name: "Foo"], name: [presence: true])
+      :ok
+
+      iex> Vex.validate([name: "Foo"], name: [absence: true])
+      {:error, [{:name, :absence, "must be absent"}]}
+  """
+  @spec validate(term, Keyword.t) :: :ok | {:error, [{attribute, name, term}]}
+  def validate(data) do
+    validate(data, Vex.Extract.settings(data))
+  end
+  def validate(data, settings) do
+    case errors(data, settings) do
+      [] ->
+        :ok
+      errors when is_list(errors) ->
+        {:error, (for {:error, a, n, m} <- errors, do: {a, n, m})}
+    end
+  end
+
   def valid?(data) do
     valid?(data, Vex.Extract.settings(data))
   end
@@ -18,30 +48,51 @@ defmodule Vex do
     results(data, Vex.Extract.settings(data))
   end
   def results(data, settings) do
-    Enum.map(settings, fn ({attribute, validations}) ->
-      if is_function(validations) do
-        validations = [by: validations]
-      end
-      Enum.map(validations, fn ({name, options}) ->
-        result(data, attribute, name, options)
-      end)
-    end)
-  |>
-    List.flatten
+    for {attribute, validations} <- settings do
+      result({data, attribute}, validations)
+    end
+    |> List.flatten
   end
 
-  defp result(data, attribute, name, options) do
-    v = validator(name)
+  @doc """
+  Return the result of apply the validations to the data.
+
+  ## Examples
+
+      iex> Vex.result("Foo", length: [min: 2, max: 10])
+      [{:ok, nil, :length}]
+
+      iex> Vex.result("Foo", length: [min: 4, max: 10])
+      [{:error, nil, :length, "must have a length between 4 and 10"}]
+  """
+  @spec result(term, Keyword.t) :: [ok_result | error_result]
+  def result(data, func) when is_function(func) do
+    result(data, [by: func])
+  end
+  def result(data, validations) do
+    for {name, options} <- validations do
+      result(data, name, options)
+    end
+  end
+
+  @doc false
+  @spec result(term, name, Keyword.t) :: ok_result | error_result
+  defp result({data, attribute}, name, options) do
     if Vex.Validator.validate?(data, options) do
-      result = extract(data, attribute, name) |> v.validate(options)
-      case result do
-        {:error, message} -> {:error, attribute, name, message}
-        :ok -> {:ok, attribute, name}
-        _ -> raise "'#{name}'' validator should return :ok or {:error, message}"
-      end
+      result({data, attribute, extract(data, attribute, name)}, name, options)
     else
       {:not_applicable, attribute, name}
     end
+  end
+  defp result({_, attribute, value}, name, options) do
+    case validator(name).validate(value, options) do
+      {:error, message} -> {:error, attribute, name, message}
+      :ok -> {:ok, attribute, name}
+      _ -> raise "'#{name}'' validator should return :ok or {:error, message}"
+    end
+  end
+  defp result(value, name, options) do
+    result({nil, nil, value}, name, options)
   end
 
   @doc """

--- a/test/vex_test.exs
+++ b/test/vex_test.exs
@@ -8,10 +8,15 @@ defmodule VexTest do
     assert_raise Vex.InvalidValidatorError, fn ->
       Vex.valid?([name: "Foo"], name: [foobar: true])
     end
+
+    assert_raise Vex.InvalidValidatorError, fn ->
+      Vex.validate([name: "Foo"], name: [foobar: true])
+    end
   end
 
   test "keyword list, provided multiple validations" do
     assert Vex.valid?([name: "Foo"], name: [presence: true, length: [min: 2, max: 10], format: ~r(^Fo.$)])
+    assert :ok == Vex.validate([name: "Foo"], name: [presence: true, length: [min: 2, max: 10], format: ~r(^Fo.$)])
   end
 
   test "record, included complex validation" do
@@ -38,6 +43,9 @@ defmodule VexTest do
     assert !Vex.valid?(user)
     assert length(Vex.results(user)) > 0
     assert length(Vex.errors(user)) == 2
+
+    {:error, errors} = Vex.validate(user)
+    assert length(errors) == length(Vex.errors(user))
   end
 
   test "keyword list, included complex validation with non-applicable validations" do


### PR DESCRIPTION
`result/2` is an intermediate function that can be used to validate an extracted value. `validate/1,2` provides an alternate tuple summary of validation.

This functionality is useful to me, but the functions might not be the best way to provide the interface. Feedback would be great!
