### PR TITLE
each validator: validate each element in an enumerable according to validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,18 @@ If you only want the errors, use `Vex.errors/1`:
 iex> Vex.errors(another_user)
 [{:error, :password, :length, "must have a length of at least 4"},
  {:error, :password, :confirmation, "must match its confirmation"}]
- ```
+```
+
+The results can be gathered with `Vex.validate/1`:
+
+```elixir
+iex> Vex.results(user)
+:ok
+
+iex> Vex.errors(another_user)
+{:error, [{:password, :length, "must have a length of at least 4"},
+          {:password, :confirmation, "must match its confirmation"}]
+```
 
 Custom Error Messages
 ---------------------

--- a/lib/vex.ex
+++ b/lib/vex.ex
@@ -1,5 +1,35 @@
 defmodule Vex do
 
+  @typep attribute    :: atom
+  @typep name         :: atom
+  @typep error_result :: {:error, attribute, name, term}
+  @typep ok_result    :: {:ok, attribute, name}
+
+
+  @doc """
+  Return `:ok` or an error tuple with the list of errors.
+
+  ## Examples
+
+      iex> Vex.validate([name: "Foo"], name: [presence: true])
+      :ok
+
+      iex> Vex.validate([name: "Foo"], name: [absence: true])
+      {:error, [{:name, :absence, "must be absent"}]}
+  """
+  @spec validate(term, Keyword.t) :: :ok | {:error, [{attribute, name, term}]}
+  def validate(data) do
+    validate(data, Vex.Extract.settings(data))
+  end
+  def validate(data, settings) do
+    case errors(data, settings) do
+      [] ->
+        :ok
+      errors when is_list(errors) ->
+        {:error, (for {:error, a, n, m} <- errors, do: {a, n, m})}
+    end
+  end
+
   def valid?(data) do
     valid?(data, Vex.Extract.settings(data))
   end
@@ -18,30 +48,51 @@ defmodule Vex do
     results(data, Vex.Extract.settings(data))
   end
   def results(data, settings) do
-    Enum.map(settings, fn ({attribute, validations}) ->
-      if is_function(validations) do
-        validations = [by: validations]
-      end
-      Enum.map(validations, fn ({name, options}) ->
-        result(data, attribute, name, options)
-      end)
-    end)
-  |>
-    List.flatten
+    for {attribute, vs} <- settings do
+      result({data, attribute}, (if is_function(vs), do: [by: vs], else: vs))
+    end
+    |> List.flatten
   end
 
-  defp result(data, attribute, name, options) do
-    v = validator(name)
+  @doc """
+  Return the result of apply the validations to the data.
+
+  ## Examples
+
+      iex> Vex.result("Foo", length: [min: 2, max: 10])
+      [{:ok, nil, :length}]
+
+      iex> Vex.result("Foo", length: [min: 4, max: 10])
+      [{:error, nil, :length, "must have a length between 4 and 10"}]
+  """
+  @spec result(term, Keyword.t) :: [ok_result | error_result]
+  def result(data, func) when is_function(func) do
+    result(data, [by: func])
+  end
+  def result(data, validations) do
+    for {name, options} <- validations do
+      result(data, name, options)
+    end
+  end
+
+  @doc false
+  @spec result(term, name, Keyword.t) :: ok_result | error_result
+  defp result({data, attribute}, name, options) do
     if Vex.Validator.validate?(data, options) do
-      result = extract(data, attribute, name) |> v.validate(options)
-      case result do
-        {:error, message} -> {:error, attribute, name, message}
-        :ok -> {:ok, attribute, name}
-        _ -> raise "'#{name}'' validator should return :ok or {:error, message}"
-      end
+      result({data, attribute, extract(data, attribute, name)}, name, options)
     else
       {:not_applicable, attribute, name}
     end
+  end
+  defp result({_, attribute, value}, name, options) do
+    case validator(name).validate(value, options) do
+      {:error, message} -> {:error, attribute, name, message}
+      :ok -> {:ok, attribute, name}
+      _ -> raise "'#{name}'' validator should return :ok or {:error, message}"
+    end
+  end
+  defp result(value, name, options) do
+    result({nil, nil, value}, name, options)
   end
 
   @doc """

--- a/lib/vex.ex
+++ b/lib/vex.ex
@@ -48,8 +48,8 @@ defmodule Vex do
     results(data, Vex.Extract.settings(data))
   end
   def results(data, settings) do
-    for {attribute, vs} <- settings do
-      result({data, attribute}, (if is_function(vs), do: [by: vs], else: vs))
+    for {attribute, validations} <- settings do
+      result({:extract, {data, attribute}}, validations)
     end
     |> List.flatten
   end
@@ -77,14 +77,15 @@ defmodule Vex do
 
   @doc false
   @spec result(term, name, Keyword.t) :: ok_result | error_result
-  defp result({data, attribute}, name, options) do
+  defp result({:extract, {data, attribute}}, name, options) do
     if Vex.Validator.validate?(data, options) do
-      result({data, attribute, extract(data, attribute, name)}, name, options)
+      result({:extract, {data, attribute, extract(data, attribute, name)}},
+             name, options)
     else
       {:not_applicable, attribute, name}
     end
   end
-  defp result({_, attribute, value}, name, options) do
+  defp result({:extract, {_, attribute, value}}, name, options) do
     case validator(name).validate(value, options) do
       {:error, message} -> {:error, attribute, name, message}
       :ok -> {:ok, attribute, name}
@@ -92,7 +93,7 @@ defmodule Vex do
     end
   end
   defp result(value, name, options) do
-    result({nil, nil, value}, name, options)
+    result({:extract, {nil, nil, value}}, name, options)
   end
 
   @doc """

--- a/lib/vex/validator/skipping.ex
+++ b/lib/vex/validator/skipping.ex
@@ -39,11 +39,13 @@ defmodule Vex.Validator.Skipping do
       iex> Vex.Validator.Skipping.skip?(1, allow_blank: true, allow_nil: true)
       false
   """
-  def skip?(value, options) do
+  def skip?(value, options) when is_list(options) do
     cond do
       Keyword.get(options, :allow_blank) -> Vex.Blank.blank?(value)
       Keyword.get(options, :allow_nil)   -> value == nil
       true -> false
     end
   end
+  def skip?(_value, _options), do: false
+
 end

--- a/lib/vex/validators/each.ex
+++ b/lib/vex/validators/each.ex
@@ -1,0 +1,58 @@
+defmodule Vex.Validators.Each do
+  @moduledoc """
+  Run the validation options across each item in the enumerable.
+
+  ## Examples
+
+      iex> Vex.Validators.Each.validate([1, 2], &is_integer/1)
+      :ok
+
+      iex> Vex.Validators.Each.validate(
+      ...>   %{a: 1, b: 2}, fn ({k, v}) -> is_atom(k) and is_integer(v) end)
+      :ok
+
+      iex> Vex.Validators.Each.validate([1, :b], &is_integer/1)
+      {:error, ["must be valid"]}
+
+      iex> Vex.Validators.Each.validate(1, &is_integer/1)
+      {:error, :not_enumerable}
+
+      iex> Vex.Validators.Each.validate([1, 2], [validators: &is_integer/1])
+      :ok
+
+      iex> Vex.Validators.Each.validate(
+      ...>   [1, 2], [validators: [by: &is_integer/1], allow_nil: true])
+      :ok
+
+      iex> Vex.Validators.Each.validate(
+      ...>   nil, [validators: [by: &is_integer/1], allow_nil: true])
+      :ok
+  """
+  use Vex.Validator
+
+  @validators_key :validators
+
+
+  def validate(list, func) when is_function(func) do
+    validate(list, [{@validators_key, func}])
+  end
+  def validate(list, options) do
+    unless_skipping(list, options) do
+      validators = Dict.fetch!(options, @validators_key)
+      try do
+        list
+          |> Enum.map(&Vex.result(&1, validators))
+          |> List.flatten()
+          |> Enum.filter(fn ({:ok, _, _}) -> false; (_) -> true end)
+      rescue
+        Protocol.UndefinedError ->
+          {:error, :not_enumerable}
+       else
+        [] ->
+          :ok
+        errors when is_list(errors) ->
+          {:error, (for {:error, _, _, message} <- errors, do: message)}
+      end
+    end
+  end
+end

--- a/test/doc_test.exs
+++ b/test/doc_test.exs
@@ -2,7 +2,7 @@ defmodule DocTest do
   use ExUnit.Case
   # Main
   doctest Vex
-  doctest Vex.Validator  
+  doctest Vex.Validator
   # Validator Utilities
   doctest Vex.Validator.ErrorMessage
   doctest Vex.Validator.Skipping
@@ -16,4 +16,5 @@ defmodule DocTest do
   doctest Vex.Validators.Inclusion
   doctest Vex.Validators.Length
   doctest Vex.Validators.Presence
+  doctest Vex.Validators.Each
 end

--- a/test/validations/each_test.exs
+++ b/test/validations/each_test.exs
@@ -1,0 +1,21 @@
+defmodule EachTest do
+  use ExUnit.Case
+
+  test "each validator, against a list" do
+    assert :ok == Vex.Validators.Each.validate([1, 2], &is_integer/1)
+    assert {:error, ["must be valid"]} ==
+      Vex.Validators.Each.validate([1, "b"], &is_integer/1)
+  end
+
+  test "each validator, against non-enumerable" do
+    assert {:error, :not_enumerable} ==
+      Vex.Validators.Each.validate(1, &is_integer/1)
+  end
+
+  test "each validator, against a dict" do
+    valid? = fn ({k, v}) -> is_atom(k) and is_integer(v) end
+    assert :ok == Vex.Validators.Each.validate(%{a: 1, b: 2}, valid?)
+    assert {:error, ["must be valid"]} ==
+      Vex.Validators.Each.validate(%{a: 1, b: :c}, valid?)
+  end
+end

--- a/test/vex_test.exs
+++ b/test/vex_test.exs
@@ -8,10 +8,15 @@ defmodule VexTest do
     assert_raise Vex.InvalidValidatorError, fn ->
       Vex.valid?([name: "Foo"], name: [foobar: true])
     end
+
+    assert_raise Vex.InvalidValidatorError, fn ->
+      Vex.validate([name: "Foo"], name: [foobar: true])
+    end
   end
 
   test "keyword list, provided multiple validations" do
     assert Vex.valid?([name: "Foo"], name: [presence: true, length: [min: 2, max: 10], format: ~r(^Fo.$)])
+    assert :ok == Vex.validate([name: "Foo"], name: [presence: true, length: [min: 2, max: 10], format: ~r(^Fo.$)])
   end
 
   test "record, included complex validation" do
@@ -38,6 +43,9 @@ defmodule VexTest do
     assert !Vex.valid?(user)
     assert length(Vex.results(user)) > 0
     assert length(Vex.errors(user)) == 2
+
+    {:error, errors} = Vex.validate(user)
+    assert length(errors) == length(Vex.errors(user))
   end
 
   test "keyword list, included complex validation with non-applicable validations" do

--- a/test/vex_test.exs
+++ b/test/vex_test.exs
@@ -14,6 +14,11 @@ defmodule VexTest do
     end
   end
 
+  test "keyword list, each validation" do
+    assert  Vex.valid?([tags: ["a", "b"]], tags: [each: &is_binary/1])
+    assert !Vex.valid?([tags: [1, "b"]], tags: [each: &is_binary/1])
+  end
+
   test "keyword list, provided multiple validations" do
     assert Vex.valid?([name: "Foo"], name: [presence: true, length: [min: 2, max: 10], format: ~r(^Fo.$)])
     assert :ok == Vex.validate([name: "Foo"], name: [presence: true, length: [min: 2, max: 10], format: ~r(^Fo.$)])


### PR DESCRIPTION
This supersedes https://github.com/CargoSense/vex/pull/9.

The trick to using vex recursively is to have a function which can be used to validate a value given a list of validations. This would complement the current `Vex.valid?/1,2` functions which require a `Vex.Extract` implementer and a dictionary mapping keys to lists of validations.

Here's what the signature of this function might look like:

```elixir
@doc "Validate the `value` given the `validations`."
@spec validate_value(term, Keyword.t) :: ...
def validate_value(value, validators)
```

I hacked this functionality into `result/2`, but it's ugly due to needing different behavior if called from `results/2` vs directly. Alternatively, I could revert Vex's results functions back to how they were, and just add `validate_value/2` as a separate function. 

Again, there's no readme doc since I imagine this will see some changes.