### PR TITLE
Conditional Custom Presence Validation

### DIFF
--- a/lib/vex/validator.ex
+++ b/lib/vex/validator.ex
@@ -64,6 +64,10 @@ defmodule Vex.Validator do
     !!condition.(data)
   end
 
+  defp do_validate_if_condition(data, {name, condition}) when is_atom(name) and is_function(condition) do
+    attribute = Vex.Extract.attribute(data, name)
+    !!condition.(attribute)
+  end
   defp do_validate_if_condition(data, {name, value}) when is_atom(name) do
     Vex.Extract.attribute(data, name) == value
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,10 +7,17 @@ end
 
 defmodule UserTest do
   use Vex.Struct
-  defstruct username: nil, password: nil, password_confirmation: nil, age: nil
+  defstruct username: nil, password: nil, password_confirmation: nil, age: nil, phone: nil, role: nil
+
+  defmodule Validations do
+    def is_privileged(value) do
+      value in ~w(admin superuser)a
+    end
+  end
 
   validates :username, presence: true, length: [min: 4], format: ~r/(^[[:alpha:]][[:alnum:]]+$)/
   validates :password, length: [min: 4], confirmation: true
+  validates :phone, presence: [if: [role: &Validations.is_privileged/1]]
 
 end
 

--- a/test/vex_test.exs
+++ b/test/vex_test.exs
@@ -22,6 +22,15 @@ defmodule VexTest do
     assert UserTest.valid?(user)
   end
 
+  test "record, included complex validation with errors" do
+    user = %UserTest{username: "actualuser", password: "abcdefghi", password_confirmation: "abcdefghi",
+      phone: nil, role: :admin}
+    assert !Vex.valid?(user)
+    assert length(Vex.results(user)) > 0
+    assert length(Vex.errors(user)) == 1
+    assert !UserTest.valid?(user)
+  end
+
   test "keyword list, included complex validation" do
     user = [username: "actualuser", password: "abcdefghi", password_confirmation: "abcdefghi",
             _vex: [username: [presence: true, length: [min: 4], format: ~r(^[[:alpha:]][[:alnum:]]+$)],
@@ -32,12 +41,13 @@ defmodule VexTest do
   end
 
   test "keyword list, included complex validation with errors" do
-    user = [username: "actualuser", password: "abc", password_confirmation: "abcdefghi",
+    user = [username: "actualuser", password: "abc", password_confirmation: "abcdefghi", phone: nil, role: :admin,
             _vex: [username: [presence: true, length: [min: 4], format: ~r(^[[:alpha:]][[:alnum:]]+$)],
-                   password: [length: [min: 4], confirmation: true]]]
+                   password: [length: [min: 4], confirmation: true],
+                   phone: [presence: [if: [role: &(&1 in ~w(admin superuser)a)]]]]]
     assert !Vex.valid?(user)
     assert length(Vex.results(user)) > 0
-    assert length(Vex.errors(user)) == 2
+    assert length(Vex.errors(user)) == 3
   end
 
   test "keyword list, included complex validation with non-applicable validations" do


### PR DESCRIPTION
Hi,
I had a need for a presence validation conditional on the value of another attribute.
To illustrate, here is an example where if a user's role is `:admin` or `:superuser`, the attribute `phone` must be present:
```elixir
defmodule UserTest do 
  use Vex.Struct
  defstruct username: nil, password: nil, password_confirmation: nil, age: nil, phone: nil,
            role: nil

  defmodule Validations do 
    def is_privileged(value) do 
      value in ~w(admin superuser)a
    end
  end

  validates :username, presence: true, length: [min: 4], format: ~r/(^[[:alpha:]][[:alnum:]]+$)/
  validates :password, length: [min: 4], confirmation: true
  validates :phone, presence: [if: [role: &Validations.is_privileged/1]]
end
```
After struggling for a while, I came to the conclusion that adding this feature to Vex, instead of trying to work around it, was the best strategy. Hope it will be helpful.
Cheers!