### PR TITLE
Adding if_any and unless_any validation conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /deps
 erl_crash.dump
 *.ez
+*.swp
 _build

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ See the documentation on `Vex.Validators.By` for details on available options.
 Validation Conditions
 ---------------------
 
-A validation can be made applicable (or unapplicable) by using the `:if`
-and `:unless` options.
+A validation can be made applicable (or unapplicable) by using the `:if`,
+`:if_any`, `:unless` and `:unless_any` options.
 
 Note `Vex.results` will return tuples with `:not_applicable` for validations that
 are skipped as a result of failing conditions.
@@ -203,12 +203,42 @@ Require a post to have a `body` of at least 200 bytes unless a non-blank
 iex> Vex.valid?(post, body: [length: [min: 200, unless: :reference_url]])
 ```
 
+### Based on other attributes' presence
+
+Require a post to have a `body` of at least 200 bytes unless a non-blank
+`reference_url`__and__ `category` are provided.
+
+```elixir
+iex> Vex.valid?(post, body: [length: [min: 200, unless: [:reference_url, :category]]])
+```
+
+Require a post to have a `body` of at least 200 bytes unless a non-blank
+`reference_url` __or__ `category` is provided.
+
+```elixir
+iex> Vex.valid?(post, body: [length: [min: 200, unless_any: [:reference_url, :category]]])
+```
+
 ### Based on another attribute's value
 
 Only require a password if the `state` of a user is `:new`:
 
 ```elixir
 iex> Vex.valid?(user, password: [presence: [if: [state: :new]]]
+```
+
+### Based on other attributes' value
+
+Only require a password if the `state` of a user is `:new` __and__ she is not from Facebook:
+
+```elixir
+iex> Vex.valid?(user, password: [presence: [if: [state: :new, from_facebook: false]]]
+```
+
+Only require a password if the `state` of a user is `:new` __or__ she is not from Facebook:
+
+```elixir
+iex> Vex.valid?(user, password: [presence: [if_any: [state: :new, from_facebook: false]]]
 ```
 
 ### Based on a custom function

--- a/lib/vex/validator.ex
+++ b/lib/vex/validator.ex
@@ -81,10 +81,10 @@ defmodule Vex.Validator do
       :any -> Enum.any?(conditions, &do_validate_if_condition(data, &1))
     end
   end
-  defp validate_if(data, condition) when is_atom(condition) do
+  defp validate_if(data, condition, _opt) when is_atom(condition) do
     do_validate_if_condition(data, condition)
   end
-  defp validate_if(data, condition) when is_function(condition) do
+  defp validate_if(data, condition, _opt) when is_function(condition) do
     !!condition.(data)
   end
 

--- a/lib/vex/validator.ex
+++ b/lib/vex/validator.ex
@@ -44,18 +44,42 @@ defmodule Vex.Validator do
     false
     iex> Vex.Validator.validate?([name: "foo"], unless: &(&1[:name] != "foo"))
     true
+
+  If the data does/doesn't match a list of conditions:
+
+    iex> Vex.Validator.validate?([name: "foo", state: "new"], if: [name: "foo", state: "new"])
+    true
+    iex> Vex.Validator.validate?([name: "foo", state: "persisted"], if: [name: "foo", state: "new"])
+    false
+    iex> Vex.Validator.validate?([name: "foo", state: "persisted"], if_any: [name: "foo", state: "new"])
+    true
+    iex> Vex.Validator.validate?([name: "foo", state: "persisted"], if_any: [name: "bar", state: "new"])
+    false
+    iex> Vex.Validator.validate?([name: "foo", state: "new"], unless: [name: "foo", state: "new"])
+    false
+    iex> Vex.Validator.validate?([name: "foo", state: "persisted"], unless: [name: "foo", state: "new"])
+    true
+    iex> Vex.Validator.validate?([name: "foo", state: "persisted"], unless_any: [name: "foo", state: "new"])
+    false
+    iex> Vex.Validator.validate?([name: "foo", state: "persisted"], unless_any: [name: "bar", state: "new"])
+    true
   """
   def validate?(data, options) when is_list(options) do
     cond do
-      Keyword.has_key?(options, :if) -> validate_if(data, Keyword.get(options, :if))
-      Keyword.has_key?(options, :unless) -> !validate_if(data, Keyword.get(options, :unless))
+      Keyword.has_key?(options, :if) -> validate_if(data, Keyword.get(options, :if), :all)
+      Keyword.has_key?(options, :if_any) -> validate_if(data, Keyword.get(options, :if_any), :any)
+      Keyword.has_key?(options, :unless) -> !validate_if(data, Keyword.get(options, :unless), :all)
+      Keyword.has_key?(options, :unless_any) -> !validate_if(data, Keyword.get(options, :unless_any), :any)
       true -> true
     end
   end
   def validate?(_data, _options), do: true
 
-  defp validate_if(data, conditions) when is_list(conditions) do
-    Enum.all?(conditions, &do_validate_if_condition(data, &1))
+  defp validate_if(data, conditions, opt) when is_list(conditions) do
+    case opt do
+      :all -> Enum.all?(conditions, &do_validate_if_condition(data, &1))
+      :any -> Enum.any?(conditions, &do_validate_if_condition(data, &1))
+    end
   end
   defp validate_if(data, condition) when is_atom(condition) do
     do_validate_if_condition(data, condition)


### PR DESCRIPTION
Hi,
I ran into a situation where I needed this functionality. Thought it would be a worthy addition to Vex.

A validation is applicable (or unapplicable) by using `if` and `unless` options. If given a list of conditions, the validation is applicable if __all__ elements of the list evaluate to `true` whereas `if_any` and `unless_any` are triggered if __at least one__ element of the list evaluates to `true`.
```elixir
iex> Vex.Validator.validate?([name: "foo", state: "persisted"], if: [name: "foo", state: "new"])
false
iex> Vex.Validator.validate?([name: "foo", state: "persisted"], if_any: [name: "foo", state: "new"])
true

iex> Vex.Validator.validate?([name: "foo", state: "persisted"], unless: [name: "foo", state: "new"])
true
iex> Vex.Validator.validate?([name: "foo", state: "persisted"], unless_any: [name: "foo", state: "new"])
false
```
Hope it will be useful :smiley: 