### PR TITLE
Add ability to use parent of the attribute in 'by' validator

### DIFF
--- a/lib/vex.ex
+++ b/lib/vex.ex
@@ -33,7 +33,7 @@ defmodule Vex do
   defp result(data, attribute, name, options) do
     v = validator(name)
     if Vex.Validator.validate?(data, options) do
-      result = extract(data, attribute, name) |> v.validate(options)
+      result = extract(data, attribute, name) |> v.validate(data, options)
       case result do
         {:error, message} -> {:error, attribute, name, message}
         :ok -> {:ok, attribute, name}

--- a/lib/vex/validator.ex
+++ b/lib/vex/validator.ex
@@ -8,6 +8,12 @@ defmodule Vex.Validator do
       @behaviour Vex.Validator.Behaviour
       import Vex.Validator.Skipping
       use Vex.Validator.ErrorMessage
+
+      def validate(data, _context, options) do
+        validate(data, options)
+      end
+
+      defoverridable [validate: 3]
     end
   end
 

--- a/lib/vex/validator/behaviour.ex
+++ b/lib/vex/validator/behaviour.ex
@@ -2,4 +2,7 @@ defmodule Vex.Validator.Behaviour do
   use Behaviour
 
   defcallback validate(data :: any, options :: any) :: atom | {atom, String.t}
+
+  defcallback validate(data :: any, context :: any, options :: any) :: atom | {atom, String.t}
+
 end

--- a/lib/vex/validators/by.ex
+++ b/lib/vex/validators/by.ex
@@ -59,9 +59,15 @@ defmodule Vex.Validators.By do
   @message_fields [value: "The bad value"]
   def validate(value, func) when is_function(func), do: validate(value, function: func)
   def validate(value, options) when is_list(options) do
+    validate(value, nil, options)
+  end
+
+  @message_fields [value: "The bad value"]
+  def validate(value, context, func) when is_function(func), do: validate(value, context, function: func)
+  def validate(value, context, options) when is_list(options) do
     unless_skipping(value, options) do
       function = Keyword.get(options, :function)
-      case function.(value) do
+      case call_function(function, value, context) do
         {:error, reason} ->
           {:error, reason}
         falsy when falsy === false or falsy === nil ->
@@ -71,4 +77,8 @@ defmodule Vex.Validators.By do
       end
     end
   end
+
+  defp call_function(f, value, _context) when is_function(f, 1), do: f.(value)
+  defp call_function(f, value, context) when is_function(f, 2), do: f.(value, context)
+
 end

--- a/test/validations/by_test.exs
+++ b/test/validations/by_test.exs
@@ -18,4 +18,13 @@ defmodule ByTest do
       Vex.errors([component: "z1234"], component: x1234_match)
   end
 
+  test "context dependent validations" do
+    x1234_match = fn("x1234", [component: _, validate: true]) -> :ok; (_, _) -> {:error, :bad_param} end
+    assert  Vex.valid?([component: "x1234", validate: true], component: x1234_match)
+    assert !Vex.valid?([component: "z1234", validate: false], component: x1234_match)
+
+    assert [{:error, :component, :by, :bad_param}] ==
+      Vex.errors([component: "x1234", validate: false], component: x1234_match)
+  end
+
 end


### PR DESCRIPTION
As mentioned in issue #15 cross-field dependent validation is not possible in vex due to the fact that validators are not provided with the field-surrounding context. This PR does the following;

- it declares an extra validate/3 function on Vex.Validator.Behaviour
- changes Vex.Validator to implement the new function in all existing 
  validators that do not take advantage of the new context (backwards compatibility)
- modify Vex.Validators.By to take advantage of the new optional context param