### PR TITLE
Use Inflex camelize as opposed to Mix.Utils.

### DIFF
--- a/lib/vex/validator/source.ex
+++ b/lib/vex/validator/source.ex
@@ -6,7 +6,7 @@ end
 
 defimpl Vex.Validator.Source, for: Atom do
 
-  import Mix.Utils, only: [camelize: 1]
+  import Inflex, only: [camelize: 1]
 
   def lookup(source, name) do
     validator_by_function(source, name) || validator_by_structure(source, name)

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,9 @@ defmodule Vex.Mixfile do
   end
 
   defp deps do
-    []
+    [
+      {:inflex, "~> 1.5"}
+    ]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"inflex": {:hex, :inflex, "1.5.0"}}


### PR DESCRIPTION
Using Mix.Utils functions make using vex in an Erlang (exrm) release
impossible as Mix is not a dependency of the app.