### PR TITLE
fix failing tests on elixir 1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Vex.Mixfile do
       version: "0.5.4",
       elixir: "~> 1.0",
       deps: deps,
+      consolidate_protocols: Mix.env != :test,
       package: package ]
   end
 


### PR DESCRIPTION
problem: 
- since elixir 1.2 introduced automatic protocol consolidation, tests fail

solution: 
- disable protocol consolidation for test environment