### PR TITLE
Allow returning message text with parameters

### DIFF
--- a/lib/vex/validator/error_message.ex
+++ b/lib/vex/validator/error_message.ex
@@ -35,7 +35,7 @@ defmodule Vex.Validator.ErrorMessage do
   end
   def message(options, default, context) do
     message_text = message(options, default)
-    if Keyword.keyword?(options) && options[:eex] == false do
+    if (Application.get_env(:vex, :eex) == false) || (Keyword.keyword?(options) && options[:eex] == false) do
       [text: message_text, vars: extract_vars(context)]
     else
       EEx.eval_string(message_text, context)

--- a/lib/vex/validator/error_message.ex
+++ b/lib/vex/validator/error_message.ex
@@ -34,7 +34,15 @@ defmodule Vex.Validator.ErrorMessage do
     end
   end
   def message(options, default, context) do
-    message(options, default) |> EEx.eval_string(context)
+    message_text = message(options, default)
+    if Keyword.keyword?(options) && options[:eex] == false do
+      [text: message_text, vars: extract_vars(context)]
+    else
+      EEx.eval_string(message_text, context)
+    end
   end
- 
+
+  defp extract_vars(context) do
+    Enum.filter context, fn({key, value}) -> is_boolean(value) || is_number(value) || is_binary(value) || is_nil(value) end
+  end
 end

--- a/test/vex_test.exs
+++ b/test/vex_test.exs
@@ -56,6 +56,11 @@ defmodule VexTest do
     assert {:error, [{:error, :name, :length, "must have a length of at least 4"}]} = Vex.validate([name: "Foo"], name: [length: [min: 4]])
   end
 
+  test "validate returns {:error, {text: message, vars: [min: 4, ...]}} if EEx is disabled" do
+    result = Vex.validate([name: "Foo"], name: [length: [min: 4, eex: false, message: "too short, min ${min} chars"]])
+    assert {:error, [{:error, :name, :length, [text: "too short, min ${min} chars", vars: [value: "Foo", size: 3, min: 4, max: nil]]}]} = result
+  end
+
   test "validator lookup by structure" do
     validator = Vex.validator(:criteria, [TestValidatorSourceByStructure])
     assert validator == TestValidatorSourceByStructure.Criteria


### PR DESCRIPTION
I am uncertain if this is helpful for other prople, but let's see what you guys think.

I have an app that performs validations using Vex. The app is divided into API and front-end. API returns error messages that I want to run through gettext (i18next to be precise) on client side.

This patch allows disabling EEX processing of validation messages, and let user decide what they want to do with it. In my case, I am replacing them with custom error messages and send down to client through an API. But I can imagine there may be other use cases as well.

You can globally disable EEX processing in confing, or decide on individual validations.
