### PR TITLE
Provide failed regex to custom error messages.

### DIFF
--- a/lib/vex/validators/format.ex
+++ b/lib/vex/validators/format.ex
@@ -31,7 +31,7 @@ defmodule Vex.Validators.Format do
   Custom error messages (in EEx format), provided as :message, can use the following values:
 
       iex> Vex.Validators.Format.__validator__(:message_fields)
-      [value: "The bad value"]
+      [value: "The bad value", pattern: "The regex that didn't match"]
 
   An example:
 
@@ -40,12 +40,12 @@ defmodule Vex.Validators.Format do
   """
   use Vex.Validator
 
-  @message_fields [value: "The bad value"]
+  @message_fields [value: "The bad value", pattern: "The regex that didn't match"]
   def validate(value, options) when is_list(options) do
     unless_skipping(value, options) do
       pattern = Keyword.get(options, :with)
       result Regex.match?(pattern, to_string(value)),
-                          message(options, "must have the correct format", value: value)
+                          message(options, "must have the correct format", value: value, pattern: pattern)
     end
   end
 

--- a/test/validations/format_test.exs
+++ b/test/validations/format_test.exs
@@ -7,4 +7,13 @@ defmodule FormatTest do
     assert !Vex.valid?([component: nil], component: [format: [with: ~r/(^x\d+$)/]])
   end
 
+  test "custom error messages" do
+    assert Vex.errors([component: "will not match"],
+                      [component: [format: [with: ~r/foo/, message: "Custom!"]]])
+            == [{:error, :component, :format, "Custom!"}]
+    assert Vex.errors([component: "will not match"],
+                      [component: [format: [with: ~r/foo/, message: "'<%= value %>' doesn't match <%= inspect pattern %>"]]])
+            == [{:error, :component, :format, "'will not match' doesn't match ~r/foo/"}]
+  end
+
 end


### PR DESCRIPTION
Fixes https://github.com/CargoSense/vex/issues/23

I'm new to Elixir, so any direction in terms of formatting or idioms (or anything else) is very welcome. I tried to match what I saw in the rest of the codebase, but ¯\\\_(ツ)_/¯