### PR TITLE
Replace Code.ensure_loaded/1 with faster counterpart

### DIFF
--- a/lib/vex/validator/source.ex
+++ b/lib/vex/validator/source.ex
@@ -13,7 +13,7 @@ defimpl Vex.Validator.Source, for: Atom do
   end
 
   defp validator_by_function(source, name) do
-    Code.ensure_loaded(source)
+    FastEnsureLoaded.ensure_loaded(source)
     if function_exported?(source, :validator, 1) do
       check source.validator(name)
     end
@@ -24,7 +24,7 @@ defimpl Vex.Validator.Source, for: Atom do
   end
 
   defp check(validator) do
-    Code.ensure_loaded(validator)
+    FastEnsureLoaded.ensure_loaded(validator)
     if function_exported?(validator, :validate, 2) do
       validator
     end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Vex.Mixfile do
   end
 
   defp deps do
-    [{:ex_doc, "~> 0.16", only: :dev, runtime: false}]
+    [{:ex_doc, "~> 0.16", only: :dev, runtime: false}, {:fast_ensure_loaded, "~> 0.1.0"}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "fast_ensure_loaded": {:hex, :fast_ensure_loaded, "0.1.0", "f988c89a1e4f86d8781a2c12c60cd43772e408d0855dc487cdbcc2dc458513b5", [:mix], [{:fastglobal, "~> 1.0", [hex: :fastglobal, repo: "hexpm", optional: false]}], "hexpm"},
+  "fastglobal": {:hex, :fastglobal, "1.0.0", "f3133a0cda8e9408aac7281ec579c4b4a8386ce0e99ca55f746b9f58192f455b", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
Our benchmarks showed that `Code.ensure_loaded/1` becomes the bottleneck of our system when validating data with Vex.

I built a cached version of `Code.ensure_loaded/1` that utilises [FastGlobal](https://github.com/discordapp/fastglobal) to store a list of modules loaded in such a way.

This change brought a ~10x performance improvement on a real world application.