### PR TITLE
Add Number & UUID validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,52 @@ This validation can be skipped for `nil` or blank values by including
 See the documentation on `Vex.Validators.Length` for details on
 available options.
 
+### Number
+
+Ensure a value is a number greater than a given number:
+
+```elixir
+Vex.valid? value, number: [greater_than: 2]
+```
+
+Ensure a value is a number less than or equal to a given number:
+
+```elixir
+Vex.valid? value, number: [less_than_or_equal_to: 10]
+```
+
+Ensure a value is a number is within a given range:
+
+```elixir
+Vex.valid? value, number: [greater_than_or_equal_to: 0, less_than: 10]
+```
+
+This validation can be skipped for `nil` or blank values by including 
+`allow_nil: true` or `allow_blank: true` respectively in the options.
+
+See the documentation on `Vex.Validators.Number` for details
+on available options.
+
+### UUID
+
+Ensure a value is a valid UUID string:
+
+```elixir
+Vex.valid? value, uuid: true
+```
+
+Ensure a value is a valid UUID string in a given format:
+
+```elixir
+Vex.valid? value, uuid: [format: :hex]
+```
+
+This validation can be skipped for `nil` or blank values by including 
+`allow_nil: true` or `allow_blank: true` respectively in the options.
+
+See the documentation on `Vex.Validators.Uuid` for details
+on available options.
+
 ### Acceptance
 
 Ensure an attribute is set to a positive (or custom) value. For use

--- a/lib/vex/validators/number.ex
+++ b/lib/vex/validators/number.ex
@@ -1,0 +1,205 @@
+defmodule Vex.Validators.Number do
+  @moduledoc """
+  Ensure a value is a number.
+
+  ## Options
+
+  At least one of the following must be provided:
+
+  * `:is`: The value is a number (integer or float) or not.
+  * `:equal_to`: The value is a number equal to this number.
+  * `:greater_than` : The value is a number greater than this number.
+  * `:greater_than_or_equal_to`: The value is a number greater than or equal to this number.
+  * `:less_than` : The value is a number less than this number.
+  * `:less_than_or_equal_to`: The value is a number less than or equal to this number.
+
+  Optional:
+
+  * `:message`: A custom error message. May be in EEx format and use the fields described
+    in [Custom Error Messages](#module-custom-error-messages).
+  * `:allow_nil`: A boolean whether to skip this validation for `nil` values.
+  * `:allow_blank`: A boolean whether to skip this validaton for blank values.
+
+  The `:is` option can be provided in place of the keyword list if no other options are set.
+  When multiple options are than the validator will do an `and` logic between them.
+
+  ## Examples
+
+  Examples when using the `:is` option:
+
+      iex> Vex.Validators.Number.validate("not_a_number", is: true)
+      {:error, "must be a number"}
+      iex> Vex.Validators.Number.validate(3.14, is: true)
+      :ok
+
+      iex> Vex.Validators.Number.validate("not_a_number", is: false)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, is: false)
+      {:error, "must not be a number"}
+
+  Examples when using the boolean value in options for the `:is` option:
+
+      iex> Vex.Validators.Number.validate("not_a_number", true)
+      {:error, "must be a number"}
+      iex> Vex.Validators.Number.validate(3.14, true)
+      :ok
+
+      iex> Vex.Validators.Number.validate("not_a_number", false)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, false)
+      {:error, "must not be a number"}
+
+  Examples when using the `:equal_to` option:
+
+      iex> Vex.Validators.Number.validate(3.14, equal_to: 1.41)
+      {:error, "must be a number equal to 1.41"}
+      iex> Vex.Validators.Number.validate(3.14, equal_to: 3.14)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, equal_to: 6.28)
+      {:error, "must be a number equal to 6.28"}
+
+  Examples when using the `:greater_than` option:
+
+      iex> Vex.Validators.Number.validate(3.14, greater_than: 1.41)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, greater_than: 3.14)
+      {:error, "must be a number greater than 3.14"}
+      iex> Vex.Validators.Number.validate(3.14, greater_than: 6.28)
+      {:error, "must be a number greater than 6.28"}
+
+  Examples when using the `:greater_than_or_equal_to` option:
+
+      iex> Vex.Validators.Number.validate(3.14, greater_than_or_equal_to: 1.41)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, greater_than_or_equal_to: 3.14)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, greater_than_or_equal_to: 6.28)
+      {:error, "must be a number greater than or equal to 6.28"}
+
+  Examples when using the `:less_than` option:
+
+      iex> Vex.Validators.Number.validate(3.14, less_than: 1.41)
+      {:error, "must be a number less than 1.41"}
+      iex> Vex.Validators.Number.validate(3.14, less_than: 3.14)
+      {:error, "must be a number less than 3.14"}
+      iex> Vex.Validators.Number.validate(3.14, less_than: 6.28)
+      :ok
+
+  Examples when using the `:less_than_or_equal_to` option:
+
+      iex> Vex.Validators.Number.validate(3.14, less_than_or_equal_to: 1.41)
+      {:error, "must be a number less than or equal to 1.41"}
+      iex> Vex.Validators.Number.validate(3.14, less_than_or_equal_to: 3.14)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, less_than_or_equal_to: 6.28)
+      :ok
+
+  Examples when using the combinations of the above options:
+
+      iex> Vex.Validators.Number.validate("not_a_number", is: true, greater_than: 0, less_than_or_equal_to: 3.14)
+      {:error, "must be a number"}
+      iex> Vex.Validators.Number.validate(0, is: true, greater_than: 0, less_than_or_equal_to: 3.14)
+      {:error, "must be a number greater than 0"}
+      iex> Vex.Validators.Number.validate(1.41, is: true, greater_than: 0, less_than_or_equal_to: 3.14)
+      :ok
+      iex> Vex.Validators.Number.validate(3.14, is: true, greater_than: 0, less_than_or_equal_to: 3.14)
+      :ok
+      iex> Vex.Validators.Number.validate(6.28, is: true, greater_than: 0, less_than_or_equal_to: 3.14)
+      {:error, "must be a number less than or equal to 3.14"}
+
+  ## Custom Error Messages
+
+  Custom error messages (in EEx format), provided as :message, can use the following values:
+
+      iex> Vex.Validators.Number.__validator__(:message_fields)
+      [                             
+        value: "Bad value",         
+        is: "Is number",            
+        equal_to: "Equal to number",             
+        greater_than: "Greater than number",
+        greater_than_or_equal_to: "Greater than or equal to number",
+        less_than: "Less than number",
+        less_than_or_equal_to: "Less than or equal to number"
+      ]
+
+  An example:
+
+      iex> Vex.Validators.Number.validate(3.14, less_than: 1.41,
+      ...>                                      message: "<%= inspect value %> should be less than <%= less_than %>")
+      {:error, "3.14 should be less than 1.41"}
+  """
+
+  use Vex.Validator
+
+  @option_keys [
+    :is,
+    :equal_to,
+    :greater_than,
+    :greater_than_or_equal_to,
+    :less_than,
+    :less_than_or_equal_to
+  ]
+
+  @message_fields [
+    value: "Bad value",
+    is: "Is number",
+    equal_to: "Equal to number",
+    greater_than: "Greater than number",
+    greater_than_or_equal_to: "Greater than or equal to number",
+    less_than: "Less than number",
+    less_than_or_equal_to: "Less than or equal to number"
+  ]
+  def validate(value, options) when is_boolean(options) do
+    validate(value, is: options)
+  end
+
+  def validate(value, options) when is_list(options) do
+    unless_skipping value, options do
+      Enum.reduce_while(options, :ok, fn
+        {k, o}, _ when k in @option_keys ->
+          case do_validate(value, k, o) do
+            :ok ->
+              {:cont, :ok}
+
+            {:error, default_message} ->
+              fields =
+                options
+                |> Keyword.take(@option_keys)
+                |> Keyword.put(:value, value)
+                |> Keyword.put(:less_than, options[:less_than])
+
+              error = {:error, message(options, default_message, fields)}
+
+              {:halt, error}
+          end
+
+        _, _ ->
+          {:cont, :ok}
+      end)
+    end
+  end
+
+  defp do_validate(_, _, nil), do: :ok
+  defp do_validate(v, :is, o) when is_number(v) === o, do: :ok
+  defp do_validate(_, :is, true), do: {:error, "must be a number"}
+  defp do_validate(_, :is, false), do: {:error, "must not be a number"}
+
+  defp do_validate(_, k, o) when not is_number(o),
+    do: raise("Invalid value #{inspect(o)} for option #{k}")
+
+  defp do_validate(v, :equal_to, o) when is_number(v) and v == o, do: :ok
+  defp do_validate(_, :equal_to, o), do: {:error, "must be a number equal to #{o}"}
+  defp do_validate(v, :greater_than, o) when is_number(v) and v > o, do: :ok
+  defp do_validate(_, :greater_than, o), do: {:error, "must be a number greater than #{o}"}
+  defp do_validate(v, :greater_than_or_equal_to, o) when is_number(v) and v >= o, do: :ok
+
+  defp do_validate(_, :greater_than_or_equal_to, o),
+    do: {:error, "must be a number greater than or equal to #{o}"}
+
+  defp do_validate(v, :less_than, o) when is_number(v) and v < o, do: :ok
+  defp do_validate(_, :less_than, o), do: {:error, "must be a number less than #{o}"}
+  defp do_validate(v, :less_than_or_equal_to, o) when is_number(v) and v <= o, do: :ok
+
+  defp do_validate(_, :less_than_or_equal_to, o),
+    do: {:error, "must be a number less than or equal to #{o}"}
+end

--- a/lib/vex/validators/uuid.ex
+++ b/lib/vex/validators/uuid.ex
@@ -1,0 +1,154 @@
+defmodule Vex.Validators.Uuid do
+  @moduledoc """
+  Ensure a value is a valid UUID string.
+
+  ## Options
+
+  At least one of the following must be provided:
+
+  * `:format`: Required. An atom that defines the UUID format of the value:
+
+    * `:default`: The value must be a string with format `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx`.
+    * `:hex`: The value must be a string with the format `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`.
+    * `:urn`: The value must be a string with the format `urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxx`.
+    * `:any`: The value must be a string of any of the supported formats (`:default`, `:hex` or `:urn`).
+    * `:not_any`: The value must not be a valid UUID string.
+
+  *Note: `x` is a hex number.*
+
+  Optional:
+
+  * `:message`: A custom error message. May be in EEx format
+    and use the fields described in [Custom Error Messages](#module-custom-error-messages).
+  * `:allow_nil`: A boolean whether to skip this validation for `nil` values.
+  * `:allow_blank`: A boolean whether to skip this validaton for blank values.
+
+  The value for `:format` can be provided instead of the options keyword list.
+  Additionally, if the options is a boolean value, then:
+
+  * `true`: Is the same as the `[format: :any]` options.
+  * `false`: Is the same as the `[format: :not_any]` options.
+
+  ## Examples
+
+  Examples when using the `:any` or `true` options:
+
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a304", format: :any)
+      :ok
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a30", format: :any)
+      {:error, "must be a valid UUID string"}
+
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a304", true)
+      :ok
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a30", true)
+      {:error, "must be a valid UUID string"}
+
+  Examples when using the `:not_any` or `false` options:
+
+      iex> Vex.Validators.Uuid.validate("not_a_uuid", format: :not_any)
+      :ok
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a304", format: :not_any)
+      {:error, "must not be a valid UUID string"}
+
+      iex> Vex.Validators.Uuid.validate("not_a_uuid", false)
+      :ok
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a304", false)
+      {:error, "must not be a valid UUID string"}
+
+  Examples when using the `:default` option:
+
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a304", format: :default)
+      :ok
+      iex> Vex.Validators.Uuid.validate("02aa7f483ccd11e4b63e14109ff1a304", format: :default)
+      {:error, "must be a valid UUID string in default format"}
+
+  Examples when using the `:hex` option:
+
+      iex> Vex.Validators.Uuid.validate("02aa7f483ccd11e4b63e14109ff1a304", format: :hex)
+      :ok
+      iex> Vex.Validators.Uuid.validate("urn:uuid:02aa7f48-3ccd-11e4-b63e-14109ff1a304", format: :hex)
+      {:error, "must be a valid UUID string in hex format"}
+
+  Examples when using the `:urn` option:
+
+      iex> Vex.Validators.Uuid.validate("urn:uuid:02aa7f48-3ccd-11e4-b63e-14109ff1a304", format: :urn)
+      :ok
+      iex> Vex.Validators.Uuid.validate("02aa7f48-3ccd-11e4-b63e-14109ff1a304", format: :urn)
+      {:error, "must be a valid UUID string in urn format"}
+
+  ## Custom Error Messages
+
+  Custom error messages (in EEx format), provided as `:message`, can use the following values:
+
+      iex> Vex.Validators.Uuid.__validator__(:message_fields)
+      [value: "Bad value", format: "The UUID format"]
+
+  An example:
+
+      iex> Vex.Validators.Uuid.validate("not_a_uuid", format: :any,
+      ...>                                            message: "<%= value %> should be <%= format %> UUID")
+      {:error, "not_a_uuid should be any UUID"}
+  """
+
+  use Vex.Validator
+
+  @uuid_formats [:default, :hex, :urn]
+
+  @formats [:any, :not_any] ++ @uuid_formats
+
+  @urn_prefix "urn:uuid:"
+
+  @message_fields [value: "Bad value", format: "The UUID format"]
+  def validate(value, true), do: validate(value, format: :any)
+  def validate(value, false), do: validate(value, format: :not_any)
+  def validate(value, options) when options in @formats, do: validate(value, format: options)
+
+  def validate(value, options) when is_list(options) do
+    unless_skipping value, options do
+      format = options[:format]
+
+      case do_validate(value, format) do
+        :ok -> :ok
+        {:error, reason} -> {:error, message(options, reason, value: value, format: format)}
+      end
+    end
+  end
+
+  defp do_validate(<<_::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>>, :default) do
+    :ok
+  end
+
+  defp do_validate(<<_::256>>, :hex) do
+    :ok
+  end
+
+  defp do_validate(<<@urn_prefix, _::64, ?-, _::32, ?-, _::32, ?-, _::32, ?-, _::96>>, :urn) do
+    :ok
+  end
+
+  defp do_validate(_, format) when format in @uuid_formats do
+    {:error, "must be a valid UUID string in #{format} format"}
+  end
+
+  defp do_validate(value, :any) do
+    error = {:error, "must be a valid UUID string"}
+
+    Enum.reduce_while(@uuid_formats, error, fn format, _ ->
+      case do_validate(value, format) do
+        :ok -> {:halt, :ok}
+        _ -> {:cont, error}
+      end
+    end)
+  end
+
+  defp do_validate(value, :not_any) do
+    case do_validate(value, :any) do
+      :ok -> {:error, "must not be a valid UUID string"}
+      _ -> :ok
+    end
+  end
+
+  defp do_validate(_, format) do
+    raise "Invalid value #{inspect(format)} for option :format"
+  end
+end

--- a/test/doc_test.exs
+++ b/test/doc_test.exs
@@ -15,7 +15,9 @@ defmodule DocTest do
   doctest Vex.Validators.Format
   doctest Vex.Validators.Inclusion
   doctest Vex.Validators.Length
+  doctest Vex.Validators.Number
   doctest Vex.Validators.Presence
+  doctest Vex.Validators.Uuid
   # Built-in ErrorRenderers
   doctest Vex.ErrorRenderers.EEx
   doctest Vex.ErrorRenderers.Parameterized


### PR DESCRIPTION
Hi all,

As mentioned in the issue #46, it would be nice if we had a few validators built-in Vex.
With this PR, I am adding the number & UUID validators for Vex, which originally I had created as a separate Elixir package in the repo [StoiximanServices/vex_validators](https://github.com/StoiximanServices/vex_validators).
I've updated the code, tests and documentation, so that it meets Vex's standards and style :)

Please do take a look and give me your feedback.