### PR TITLE
Implements blank protocol for date types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: elixir
-elixir: 1.2.0
 notifications:
   recipients:
     - bruce.williams@cargosense.com
     - ben.wilson@cargosense.com
-otp_release:
-  - 18.0
+matrix:
+  include:
+    - elixir: 1.6
+      otp_release: 21.0
+    - elixir: 1.7
+      otp_release: 22.0
+    - elixir: 1.8
+      otp_release: 22.0
+    - elixir: 1.9
+      otp_release: 22.0
+    - elixir: 1.10
+      otp_release: 22.0

--- a/lib/vex/blank.ex
+++ b/lib/vex/blank.ex
@@ -36,6 +36,21 @@ defimpl Vex.Blank, for: Map do
   def blank?(map), do: map_size(map) == 0
 end
 
+defimpl Vex.Blank, for: Date do
+  def blank?(nil), do: true
+  def blank?(_), do: false
+end
+
+defimpl Vex.Blank, for: DateTime do
+  def blank?(nil), do: true
+  def blank?(_), do: false
+end
+
+defimpl Vex.Blank, for: NaiveDateTime do
+  def blank?(nil), do: true
+  def blank?(_), do: false
+end
+
 defimpl Vex.Blank, for: Any do
   def blank?(_), do: false
 end

--- a/lib/vex/validator/source.ex
+++ b/lib/vex/validator/source.ex
@@ -13,12 +13,12 @@ defimpl Vex.Validator.Source, for: Atom do
     Code.ensure_loaded(source)
 
     if function_exported?(source, :validator, 1) do
-      check source.validator(name)
+      check(source.validator(name))
     end
   end
 
   defp validator_by_structure(source, name) do
-    check Module.concat(source, camelize(Atom.to_string(name)))
+    check(Module.concat(source, camelize(Atom.to_string(name))))
   end
 
   defp check(validator) do

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Vex.Mixfile do
   end
 
   defp deps do
-    [{:ex_doc, "~> 0.16", only: :dev, runtime: false}]
+    [{:ex_doc, "~> 0.19", only: :dev, runtime: false}]
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Vex.Mixfile do
     [
       app: :vex,
       version: "0.8.0",
-      elixir: "~> 1.2",
+      elixir: "~> 1.6",
       deps: deps(),
       consolidate_protocols: Mix.env() != :test,
       package: package(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,8 @@
-%{"earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm", "1b34655872366414f69dd987cb121c049f76984b6ac69f52fff6d8fd64d29cfd"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+}

--- a/test/validations/presence_test.exs
+++ b/test/validations/presence_test.exs
@@ -12,6 +12,9 @@ defmodule PresenceTest do
     assert Vex.valid?([total: 1.0], total: [presence: true])
     assert Vex.valid?([total: 0], total: [presence: true])
     assert Vex.valid?([total: 1], total: [presence: true])
+    assert Vex.valid?([date: Date.utc_today()], date: [presence: true])
+    assert Vex.valid?([date: NaiveDateTime.utc_now()], date: [presence: true])
+    assert Vex.valid?([date: DateTime.utc_now()], date: [presence: true])
   end
 
   test "map, provided presence validation" do
@@ -31,6 +34,9 @@ defmodule PresenceTest do
 
     assert !Vex.valid?(%{"name" => "Foo"}, %{"id" => [presence: true]})
     assert !Vex.valid?(%{"name" => "Foo"}, name: [presence: true])
+    assert Vex.valid?(%{"date" => Date.utc_today()}, %{"date" => [presence: true]})
+    assert Vex.valid?(%{"date" => DateTime.utc_now()}, %{"date" => [presence: true]})
+    assert Vex.valid?(%{"date" => NaiveDateTime.utc_now()}, %{"date" => [presence: true]})
   end
 
   test "keyword list, included presence validation" do


### PR DESCRIPTION
I had the same issue that is mentioned in #51 

```
** (Protocol.UndefinedError) protocol Vex.Blank not implemented for ~U[2020-11-01 11:28:12.724702Z] of type DateTime (a struct). This protocol is implemented for the following type(s): App.XXX , Integer, Tuple, Atom, Float, List, Map, BitString
```

This PR:
 - implements the Vex.Blank protocol for `Date`, `DateTime` and `NaiveDateTime`
 - run `mix format`
 - upgrade `ex_doc` from 1.6 -> 1.9 to make it work with more recent versions of Elixir
 - update .travis.yml to test different versions of Elixir: 1.6 -> 1.10