### PR TITLE
Fix method deprecation on Elixir 1.15

### DIFF
--- a/lib/vex/validators/format.ex
+++ b/lib/vex/validators/format.ex
@@ -53,7 +53,7 @@ defmodule Vex.Validators.Format do
   end
 
   def validate(value, format) do
-    if Regex.regex?(format), do: validate(value, with: format)
+    if is_struct(format, Regex), do: validate(value, with: format)
   end
 
   defp result(true, _), do: :ok


### PR DESCRIPTION
In Elixir 1.15, `Regex.regex?` is deprecated.

Here is a PR to fix that.