### PR TITLE
Fix warnings on newer Elixir versions

### DIFF
--- a/lib/vex/extract.ex
+++ b/lib/vex/extract.ex
@@ -40,7 +40,7 @@ defmodule Vex.Extract.Struct do
 
       defimpl Vex.Extract, for: __MODULE__ do
         def settings(%{__struct__: module}) do
-          module.__vex_validations__
+          module.__vex_validations__()
         end
 
         def attribute(map, [root_attr | path]) do

--- a/lib/vex/validators/length.ex
+++ b/lib/vex/validators/length.ex
@@ -78,7 +78,7 @@ defmodule Vex.Validators.Length do
     max: "Maximum acceptable value"
   ]
   def validate(value, options) when is_integer(options), do: validate(value, is: options)
-  def validate(value, min..max), do: validate(value, in: min..max)
+  def validate(value, %Range{} = range), do: validate(value, in: range)
 
   def validate(value, options) when is_list(options) do
     unless_skipping(value, options) do


### PR DESCRIPTION
Running with newer Elixir versions, the compiling Vex leads to some warnings.
These warnings are fixed in a backwards compatible way.

The fixes include:
- Do not use min..max in a pattern match without explicitly matching the step.
- Add parens to zero-arity function calls.

Example:
When compiling/running tests, I get a lot of warnings about this:
<img width="1914" alt="image" src="https://github.com/CargoSense/vex/assets/6518376/8c78b643-2659-4c6a-a929-a9aa72ddbbf6">
